### PR TITLE
Add installer and updater automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,9 @@ SLIDESHOW_MANAGER_ALLOWED_HOSTS=localhost,127.0.0.1
 
 # Secret for encrypting session payloads (optional fallback)
 NEXTAUTH_SECRET=replace-with-strong-secret
+
+# Repository identifier (owner/repo) used for installer and updater automation
+SLIDESHOW_MANAGER_REPO=owner/Slideshow_Manager
+
+# Optional GitHub token for accessing private repositories
+# SLIDESHOW_MANAGER_REPO_TOKEN=ghp_xxx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-# Slideshow_Manager
-=======
 # Slideshow Manager
 
 A Next.js App Router project that manages one or more Slideshow appliances through a secure proxy. The project mirrors the feature set of the existing Flask-based Slideshow UI while adding fleet management tooling.
@@ -71,4 +68,11 @@ A Next.js App Router project that manages one or more Slideshow appliances throu
 
 MIT
 
->>>>>>> 3568664 (Initial commit)
+## Deployment Automation
+
+For automated installations and upgrades the repository ships with shell scripts located in `scripts/`:
+
+- `scripts/install.sh` – clones/downloads the latest `version-x.x.x` branch (or a provided branch) and installs dependencies.
+- `scripts/update.sh` – refreshes an existing installation to a selected version. If Git is not available the script falls back to downloading an archive via HTTPS.
+
+Both scripts rely on the environment variable `SLIDESHOW_MANAGER_REPO` (format: `owner/repo`) when a Git remote cannot be inferred automatically. Optional authentication against the GitHub API can be configured with `SLIDESHOW_MANAGER_REPO_TOKEN`. The update flow is also exposed in the dashboard UI (`/updates`) which lists available branches and allows administrators to trigger the shell updater directly from the browser.

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -36,6 +36,9 @@ export default async function DashboardPage({
           <Link href={`/devices/${deviceId}/sources`} className="text-slate-300 hover:text-white">
             Quellen
           </Link>
+          <Link href="/updates" className="text-slate-300 hover:text-white">
+            Updates
+          </Link>
           <form action="/api/auth/logout" method="post">
             <button className="rounded-md border border-slate-700 px-3 py-1 text-slate-300 hover:border-slate-500 hover:text-white">
               Logout

--- a/app/(dashboard)/updates/page.tsx
+++ b/app/(dashboard)/updates/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+
+type BranchResponse = {
+  branches?: string[];
+  error?: string;
+};
+
+type UpdateResponse = {
+  branch?: string;
+  output?: string;
+  error?: string;
+};
+
+function formatOutput(output?: string) {
+  if (!output) {
+    return 'Kein Ausgabelog verfügbar.';
+  }
+  return output
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .join('\n');
+}
+
+export default function UpdatesPage() {
+  const [branches, setBranches] = useState<string[]>([]);
+  const [selectedBranch, setSelectedBranch] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [result, setResult] = useState<UpdateResponse | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    async function loadBranches() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/updates/branches', { cache: 'no-store' });
+        const payload: BranchResponse = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Unbekannter Fehler beim Laden der Branches.');
+        }
+        if (!payload.branches || payload.branches.length === 0) {
+          throw new Error('Keine Version-Branches gefunden.');
+        }
+        if (isMounted) {
+          setBranches(payload.branches);
+          setSelectedBranch(payload.branches[payload.branches.length - 1]);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Branch-Liste konnte nicht geladen werden.');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+    loadBranches();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setUpdating(true);
+      setResult(null);
+      setError(null);
+      try {
+        const response = await fetch('/api/updates/run', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ branch: selectedBranch || undefined })
+        });
+        const payload: UpdateResponse = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error ?? 'Update fehlgeschlagen.');
+        }
+        setResult(payload);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Update konnte nicht gestartet werden.');
+      } finally {
+        setUpdating(false);
+      }
+    },
+    [selectedBranch]
+  );
+
+  const statusMessage = useMemo(() => {
+    if (updating) {
+      return 'Update läuft...';
+    }
+    if (result?.branch) {
+      return `Update auf ${result.branch} abgeschlossen.`;
+    }
+    return null;
+  }, [result, updating]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <header className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold">System Updates</h1>
+          <p className="text-sm text-slate-400">
+            Installiere neue Versionen der Slideshow Manager Anwendung direkt vom Server.
+          </p>
+        </div>
+        <nav className="flex items-center gap-3 text-sm">
+          <Link href="/dashboard" className="text-slate-300 hover:text-white">
+            Dashboard
+          </Link>
+          <Link href="/updates" className="text-white">
+            Updates
+          </Link>
+        </nav>
+      </header>
+
+      <section className="rounded-lg border border-slate-800 bg-slate-900 p-6">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="branch" className="block text-sm font-medium text-slate-200">
+              Verfügbare Versionen
+            </label>
+            <select
+              id="branch"
+              name="branch"
+              value={selectedBranch}
+              onChange={(event) => setSelectedBranch(event.target.value)}
+              className="mt-2 w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100 focus:border-slate-500 focus:outline-none"
+              disabled={loading || updating}
+            >
+              {branches.map((branch) => (
+                <option key={branch} value={branch}>
+                  {branch}
+                </option>
+              ))}
+            </select>
+            {loading && <p className="mt-2 text-xs text-slate-500">Branches werden geladen…</p>}
+          </div>
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {statusMessage && !error && <p className="text-sm text-emerald-400">{statusMessage}</p>}
+
+          <button
+            type="submit"
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-emerald-800"
+            disabled={loading || updating || branches.length === 0}
+          >
+            {updating ? 'Update wird ausgeführt…' : 'Update starten'}
+          </button>
+        </form>
+      </section>
+
+      <section className="rounded-lg border border-slate-800 bg-slate-900 p-6">
+        <h2 className="text-lg font-semibold text-slate-100">Update-Protokoll</h2>
+        <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-slate-950/60 p-3 text-xs text-slate-300">
+          {formatOutput(result?.output)}
+        </pre>
+      </section>
+    </main>
+  );
+}

--- a/app/api/updates/branches/route.ts
+++ b/app/api/updates/branches/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { fetchVersionBranches } from '@/lib/versioning';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const branches = await fetchVersionBranches();
+    return NextResponse.json({ branches });
+  } catch (error) {
+    console.error('Failed to fetch version branches', error);
+    return NextResponse.json(
+      { error: 'Branch-Abfrage fehlgeschlagen. Bitte prüfen Sie die Repository-Konfiguration.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/updates/run/route.ts
+++ b/app/api/updates/run/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fetchLatestVersionBranch, isVersionBranch } from '@/lib/versioning';
+
+export const dynamic = 'force-dynamic';
+
+async function ensureScriptExists(scriptPath: string) {
+  try {
+    await access(scriptPath);
+  } catch {
+    throw new Error(`Update-Skript nicht gefunden (${scriptPath}).`);
+  }
+}
+
+async function runScript(scriptPath: string, branch: string): Promise<{ exitCode: number; output: string }> {
+  await ensureScriptExists(scriptPath);
+  return new Promise((resolve, reject) => {
+    const child = spawn(scriptPath, ['--branch', branch], {
+      cwd: process.cwd(),
+      env: process.env,
+      shell: false
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.on('error', (error) => {
+      reject(error);
+    });
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 0, output });
+    });
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    let selectedBranch: string | undefined;
+    if (request.headers.get('content-type')?.includes('application/json')) {
+      const body = await request.json();
+      if (body?.branch) {
+        selectedBranch = String(body.branch);
+      }
+    }
+
+    if (selectedBranch && !isVersionBranch(selectedBranch)) {
+      return NextResponse.json(
+        { error: 'Ungültiger Branch-Name. Erwartet wird das Format version-x.x.x.' },
+        { status: 400 }
+      );
+    }
+
+    const branch = selectedBranch ?? (await fetchLatestVersionBranch());
+    if (!branch) {
+      return NextResponse.json(
+        { error: 'Kein Version-Branch gefunden. Bitte Branch manuell angeben.' },
+        { status: 400 }
+      );
+    }
+
+    const scriptPath = path.join(process.cwd(), 'scripts', 'update.sh');
+    const result = await runScript(scriptPath, branch);
+
+    if (result.exitCode !== 0) {
+      return NextResponse.json(
+        { error: 'Update fehlgeschlagen.', branch, output: result.output.trim() },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ branch, output: result.output.trim() });
+  } catch (error) {
+    console.error('Update execution failed', error);
+    return NextResponse.json(
+      { error: 'Update konnte nicht gestartet werden. Prüfen Sie die Server-Logs.' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/versioning.ts
+++ b/lib/versioning.ts
@@ -1,0 +1,77 @@
+const VERSION_BRANCH_PATTERN = /^version-(\d+)\.(\d+)\.(\d+)$/;
+
+function ensureRepoIdentifier(): string {
+  const repo = process.env.SLIDESHOW_MANAGER_REPO;
+  if (!repo) {
+    throw new Error('SLIDESHOW_MANAGER_REPO is not configured.');
+  }
+  return repo;
+}
+
+function getGithubBranchesUrl(repo: string): string {
+  return `https://api.github.com/repos/${repo}/branches?per_page=100`;
+}
+
+function parseVersion(branch: string): [number, number, number] | null {
+  const match = branch.match(VERSION_BRANCH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isVersionBranch(branch: string): boolean {
+  return VERSION_BRANCH_PATTERN.test(branch);
+}
+
+export function compareVersionBranches(a: string, b: string): number {
+  const aParts = parseVersion(a);
+  const bParts = parseVersion(b);
+  if (!aParts && !bParts) {
+    return 0;
+  }
+  if (!aParts) {
+    return -1;
+  }
+  if (!bParts) {
+    return 1;
+  }
+  for (let i = 0; i < aParts.length; i += 1) {
+    if (aParts[i] !== bParts[i]) {
+      return aParts[i] - bParts[i];
+    }
+  }
+  return 0;
+}
+
+export async function fetchVersionBranches(): Promise<string[]> {
+  const repo = ensureRepoIdentifier();
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'slideshow-manager'
+  };
+  if (process.env.SLIDESHOW_MANAGER_REPO_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.SLIDESHOW_MANAGER_REPO_TOKEN}`;
+  }
+  const response = await fetch(getGithubBranchesUrl(repo), {
+    headers,
+    cache: 'no-store'
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to load branches (${response.status}): ${body}`);
+  }
+  const data: Array<{ name: string }> = await response.json();
+  return data
+    .map((branch) => branch.name)
+    .filter(isVersionBranch)
+    .sort((a, b) => compareVersionBranches(a, b));
+}
+
+export async function fetchLatestVersionBranch(): Promise<string | null> {
+  const branches = await fetchVersionBranches();
+  if (branches.length === 0) {
+    return null;
+  }
+  return branches[branches.length - 1];
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DEFAULT_TARGET="Slideshow_Manager"
+METADATA_FILE=".slideshow-manager.json"
+BRANCH=""
+TARGET_DIR=""
+REPO_IDENTIFIER=""
+REMOTE_URL=""
+SKIP_DEPENDENCIES=0
+
+usage() {
+  cat <<USAGE
+Usage: $SCRIPT_NAME [options]
+
+Options:
+  --branch <name>        Install a specific version branch (default: latest version-*)
+  --repo <owner/repo>    Repository identifier used when no Git remote is available
+  --repo-url <url>       Explicit Git clone URL (overrides identifier derived URL)
+  --target <dir>         Installation directory (default: "+$DEFAULT_TARGET" in current directory)
+  --skip-deps            Skip dependency installation step
+  -h, --help             Show this help message
+USAGE
+}
+
+log() {
+  echo "[$SCRIPT_NAME] $*"
+}
+
+error() {
+  echo "[$SCRIPT_NAME] ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Required command '$1' is not available."
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --branch)
+        BRANCH="$2"
+        shift 2
+        ;;
+      --repo)
+        REPO_IDENTIFIER="$2"
+        shift 2
+        ;;
+      --repo-url)
+        REMOTE_URL="$2"
+        shift 2
+        ;;
+      --target)
+        TARGET_DIR="$2"
+        shift 2
+        ;;
+      --skip-deps)
+        SKIP_DEPENDENCIES=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        error "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+sanitize_path() {
+  local path="$1"
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  if [[ "$path" != /* ]]; then
+    path="$(pwd)/$path"
+  fi
+  echo "$path"
+}
+
+parse_repo_identifier() {
+  local input="$1"
+  if [[ -z "$input" ]]; then
+    echo ""
+    return
+  fi
+  if [[ "$input" == http*://* || "$input" == git@*:* ]]; then
+    echo "$input"
+    return
+  fi
+  echo "$input"
+}
+
+repo_from_git_remote() {
+  if ! command -v git >/dev/null 2>&1; then
+    return
+  fi
+  local url
+  url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    return
+  fi
+  if [[ "$url" =~ ^https?://github.com/([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  elif [[ "$url" =~ ^git@github.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+}
+
+identifier_to_remote_url() {
+  local identifier="$1"
+  if [[ -z "$identifier" ]]; then
+    echo ""
+    return
+  fi
+  if [[ "$identifier" == http*://* || "$identifier" == git@*:* ]]; then
+    echo "$identifier"
+    return
+  fi
+  echo "https://github.com/$identifier.git"
+}
+
+remote_to_http_base() {
+  local url="$1"
+  if [[ "$url" =~ ^https?://[^/]+/(.+)$ ]]; then
+    local path="${BASH_REMATCH[1]}"
+    path="${path%.git}"
+    echo "https://github.com/${path}"
+    return
+  fi
+  if [[ "$url" =~ ^git@github.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "https://github.com/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return
+  fi
+  echo ""
+}
+
+version_branch_sort() {
+  sort -t- -k2,2V
+}
+
+select_latest_branch() {
+  local branches="$1"
+  if [[ -z "$branches" ]]; then
+    echo ""
+    return
+  fi
+  echo "$branches" | grep '^version-' | version_branch_sort | tail -n1
+}
+
+latest_branch_from_git() {
+  local remote="$1"
+  local refs
+  refs=$(git ls-remote --heads "$remote" 2>/dev/null | awk '{print $2}' | sed 's#refs/heads/##' || true)
+  select_latest_branch "$refs"
+}
+
+latest_branch_from_api() {
+  local identifier="$1"
+  if [[ -z "$identifier" ]]; then
+    echo ""
+    return
+  fi
+  require_command curl
+  local response
+  response=$(curl -fsSL "https://api.github.com/repos/$identifier/branches?per_page=100" || true)
+  if [[ -z "$response" ]]; then
+    echo ""
+    return
+  fi
+  local branches
+  branches=$(echo "$response" | grep -o '"name":"version-[^"]*"' | cut -d'"' -f4 || true)
+  select_latest_branch "$branches"
+}
+
+ensure_branch() {
+  local remote="$1"
+  local identifier="$2"
+  if [[ -n "$BRANCH" ]]; then
+    echo "$BRANCH"
+    return
+  fi
+  local latest=""
+  if command -v git >/dev/null 2>&1; then
+    latest=$(latest_branch_from_git "$remote")
+  fi
+  if [[ -z "$latest" ]]; then
+    latest=$(latest_branch_from_api "$identifier")
+  fi
+  if [[ -z "$latest" ]]; then
+    error "Unable to determine the latest version branch. Provide --branch explicitly."
+  fi
+  BRANCH="$latest"
+}
+
+clone_with_git() {
+  local remote="$1"
+  local branch="$2"
+  local target="$3"
+  git clone --depth 1 --branch "$branch" "$remote" "$target"
+}
+
+download_archive() {
+  local http_base="$1"
+  local branch="$2"
+  local target="$3"
+  require_command curl
+  require_command tar
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+  local archive_url="${http_base}/archive/refs/heads/${branch}.tar.gz"
+  log "Downloading ${archive_url}"
+  curl -fsSL "$archive_url" -o "$tmpdir/archive.tgz"
+  tar -xzf "$tmpdir/archive.tgz" -C "$tmpdir"
+  local extracted
+  extracted=$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d | head -n1)
+  if [[ -z "$extracted" ]]; then
+    error "Failed to extract archive"
+  fi
+  mkdir -p "$target"
+  cp -R "$extracted"/. "$target"/
+  rm -rf "$tmpdir"
+  trap - EXIT
+}
+
+install_dependencies() {
+  local target="$1"
+  if [[ "$SKIP_DEPENDENCIES" -eq 1 ]]; then
+    log "Skipping dependency installation (requested)"
+    return
+  fi
+  if command -v pnpm >/dev/null 2>&1; then
+    (cd "$target" && pnpm install)
+  elif command -v npm >/dev/null 2>&1; then
+    (cd "$target" && npm install)
+  else
+    log "npm/pnpm not found – skipping dependency installation"
+  fi
+}
+
+write_metadata() {
+  local target="$1"
+  local identifier="$2"
+  local branch="$3"
+  cat >"$target/$METADATA_FILE" <<JSON
+{
+  "repo": "$identifier",
+  "branch": "$branch",
+  "updated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+JSON
+}
+
+main() {
+  parse_args "$@"
+  if [[ -z "$TARGET_DIR" ]]; then
+    TARGET_DIR="$DEFAULT_TARGET"
+  fi
+  TARGET_DIR=$(sanitize_path "$TARGET_DIR")
+  if [[ -z "$REPO_IDENTIFIER" ]]; then
+    REPO_IDENTIFIER="$(parse_repo_identifier "${SLIDESHOW_MANAGER_REPO:-}")"
+  fi
+  if [[ -z "$REPO_IDENTIFIER" ]]; then
+    local derived
+    derived=$(repo_from_git_remote || true)
+    if [[ -n "$derived" ]]; then
+      REPO_IDENTIFIER="$derived"
+    fi
+  fi
+  if [[ -z "$REPO_IDENTIFIER" && -z "$REMOTE_URL" ]]; then
+    error "No repository identifier provided. Use --repo or set SLIDESHOW_MANAGER_REPO."
+  fi
+  if [[ -z "$REMOTE_URL" ]]; then
+    REMOTE_URL="$(identifier_to_remote_url "$REPO_IDENTIFIER")"
+  fi
+  if [[ -z "$REMOTE_URL" ]]; then
+    error "Unable to derive a Git remote URL."
+  fi
+  ensure_branch "$REMOTE_URL" "$REPO_IDENTIFIER"
+  log "Using branch '$BRANCH'"
+  if [[ -d "$TARGET_DIR" && -n "$(ls -A "$TARGET_DIR" 2>/dev/null)" ]]; then
+    error "Target directory '$TARGET_DIR' is not empty."
+  fi
+  mkdir -p "$TARGET_DIR"
+  if command -v git >/dev/null 2>&1; then
+    log "Cloning repository via Git"
+    clone_with_git "$REMOTE_URL" "$BRANCH" "$TARGET_DIR"
+  else
+    local http_base
+    http_base="$(remote_to_http_base "$REMOTE_URL")"
+    if [[ -z "$http_base" ]]; then
+      error "Cannot derive HTTP download URL – install Git or provide a GitHub HTTPS remote."
+    fi
+    log "Downloading archive without Git"
+    download_archive "$http_base" "$BRANCH" "$TARGET_DIR"
+  fi
+  install_dependencies "$TARGET_DIR"
+  write_metadata "$TARGET_DIR" "$REPO_IDENTIFIER" "$BRANCH"
+  log "Installation complete in '$TARGET_DIR'"
+}
+
+main "$@"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+METADATA_FILE=".slideshow-manager.json"
+BRANCH=""
+REPO_IDENTIFIER=""
+REMOTE_URL=""
+ROOT_OVERRIDE=""
+SKIP_DEPENDENCIES=0
+
+usage() {
+  cat <<USAGE
+Usage: $SCRIPT_NAME [options]
+
+Options:
+  --branch <name>        Update to a specific version branch (default: latest version-*)
+  --repo <owner/repo>    Repository identifier used for archive downloads
+  --repo-url <url>       Explicit Git remote URL (overrides derived value)
+  --root <dir>           Root directory of the installation (default: repository root)
+  --skip-deps            Skip dependency installation
+  -h, --help             Show this help message
+USAGE
+}
+
+log() {
+  echo "[$SCRIPT_NAME] $*"
+}
+
+error() {
+  echo "[$SCRIPT_NAME] ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Required command '$1' is not available."
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --branch)
+        BRANCH="$2"
+        shift 2
+        ;;
+      --repo)
+        REPO_IDENTIFIER="$2"
+        shift 2
+        ;;
+      --repo-url)
+        REMOTE_URL="$2"
+        shift 2
+        ;;
+      --root)
+        ROOT_OVERRIDE="$2"
+        shift 2
+        ;;
+      --skip-deps)
+        SKIP_DEPENDENCIES=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        error "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+sanitize_path() {
+  local path="$1"
+  if [[ -z "$path" ]]; then
+    return
+  fi
+  if [[ "$path" != /* ]]; then
+    path="$(pwd)/$path"
+  fi
+  echo "$path"
+}
+
+metadata_value() {
+  local file="$1"
+  local key="$2"
+  if [[ ! -f "$file" ]]; then
+    echo ""
+    return
+  fi
+  grep -o '"'$key'"[[:space:]]*:[[:space:]]*"[^"]*"' "$file" | head -n1 | sed 's/.*"'$key'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+}
+
+repo_from_git_remote() {
+  if ! command -v git >/dev/null 2>&1; then
+    return
+  fi
+  local url
+  url=$(git -C "$ROOT_DIR" config --get remote.origin.url 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    return
+  fi
+  if [[ "$url" =~ ^https?://github.com/([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  elif [[ "$url" =~ ^git@github.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+}
+
+identifier_to_remote_url() {
+  local identifier="$1"
+  if [[ -z "$identifier" ]]; then
+    echo ""
+    return
+  fi
+  if [[ "$identifier" == http*://* || "$identifier" == git@*:* ]]; then
+    echo "$identifier"
+    return
+  fi
+  echo "https://github.com/$identifier.git"
+}
+
+remote_to_http_base() {
+  local url="$1"
+  if [[ "$url" =~ ^https?://[^/]+/(.+)$ ]]; then
+    local path="${BASH_REMATCH[1]}"
+    path="${path%.git}"
+    echo "https://github.com/${path}"
+    return
+  fi
+  if [[ "$url" =~ ^git@github.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    echo "https://github.com/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return
+  fi
+  echo ""
+}
+
+version_branch_sort() {
+  sort -t- -k2,2V
+}
+
+select_latest_branch() {
+  local branches="$1"
+  if [[ -z "$branches" ]]; then
+    echo ""
+    return
+  fi
+  echo "$branches" | grep '^version-' | version_branch_sort | tail -n1
+}
+
+latest_branch_from_git() {
+  local remote="$1"
+  local refs
+  refs=$(git ls-remote --heads "$remote" 2>/dev/null | awk '{print $2}' | sed 's#refs/heads/##' || true)
+  select_latest_branch "$refs"
+}
+
+latest_branch_from_api() {
+  local identifier="$1"
+  if [[ -z "$identifier" ]]; then
+    echo ""
+    return
+  fi
+  require_command curl
+  local response
+  response=$(curl -fsSL "https://api.github.com/repos/$identifier/branches?per_page=100" || true)
+  if [[ -z "$response" ]]; then
+    echo ""
+    return
+  fi
+  local branches
+  branches=$(echo "$response" | grep -o '"name":"version-[^"]*"' | cut -d'"' -f4 || true)
+  select_latest_branch "$branches"
+}
+
+ensure_branch() {
+  local remote="$1"
+  local identifier="$2"
+  if [[ -n "$BRANCH" ]]; then
+    return
+  fi
+  local latest=""
+  if command -v git >/dev/null 2>&1; then
+    latest=$(latest_branch_from_git "$remote")
+  fi
+  if [[ -z "$latest" ]]; then
+    latest=$(latest_branch_from_api "$identifier")
+  fi
+  if [[ -z "$latest" ]]; then
+    error "Unable to determine the latest version branch. Provide --branch explicitly."
+  fi
+  BRANCH="$latest"
+}
+
+install_dependencies() {
+  if [[ "$SKIP_DEPENDENCIES" -eq 1 ]]; then
+    log "Skipping dependency installation (requested)"
+    return
+  fi
+  if command -v pnpm >/dev/null 2>&1; then
+    (cd "$ROOT_DIR" && pnpm install)
+  elif command -v npm >/dev/null 2>&1; then
+    (cd "$ROOT_DIR" && npm install)
+  else
+    log "npm/pnpm not found – skipping dependency installation"
+  fi
+}
+
+write_metadata() {
+  local identifier="$1"
+  local branch="$2"
+  cat >"$ROOT_DIR/$METADATA_FILE" <<JSON
+{
+  "repo": "$identifier",
+  "branch": "$branch",
+  "updated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+JSON
+}
+
+update_with_git() {
+  local remote="$1"
+  local branch="$2"
+  require_command git
+  git -C "$ROOT_DIR" remote | grep -qx "origin" || git -C "$ROOT_DIR" remote add origin "$remote"
+  git -C "$ROOT_DIR" remote set-url origin "$remote"
+  git -C "$ROOT_DIR" fetch origin "$branch"
+  if git -C "$ROOT_DIR" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$ROOT_DIR" checkout "$branch"
+  else
+    git -C "$ROOT_DIR" checkout -b "$branch" "origin/$branch"
+  fi
+  git -C "$ROOT_DIR" reset --hard "origin/$branch"
+  git -C "$ROOT_DIR" clean -fd
+}
+
+update_without_git() {
+  local remote="$1"
+  local branch="$2"
+  local http_base
+  http_base=$(remote_to_http_base "$remote")
+  if [[ -z "$http_base" ]]; then
+    if [[ -n "$REPO_IDENTIFIER" ]]; then
+      http_base="https://github.com/${REPO_IDENTIFIER}"
+    fi
+  fi
+  if [[ -z "$http_base" ]]; then
+    error "Cannot derive an HTTP download URL for the repository."
+  fi
+  require_command curl
+  require_command tar
+  require_command python3
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+  local archive_url="${http_base}/archive/refs/heads/${branch}.tar.gz"
+  log "Downloading ${archive_url}"
+  curl -fsSL "$archive_url" -o "$tmpdir/archive.tgz"
+  tar -xzf "$tmpdir/archive.tgz" -C "$tmpdir"
+  local extracted
+  extracted=$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d | head -n1)
+  if [[ -z "$extracted" ]]; then
+    error "Failed to extract archive"
+  fi
+  log "Replacing application files"
+  python3 - "$extracted" "$ROOT_DIR" <<'PY'
+import os
+import shutil
+import sys
+
+src = sys.argv[1]
+dst = sys.argv[2]
+preserve = {'.env', '.env.local', '.env.production', '.slideshow-manager.json', 'node_modules'}
+
+for name in os.listdir(dst):
+    if name in preserve:
+        continue
+    path = os.path.join(dst, name)
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    else:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+for name in os.listdir(src):
+    src_path = os.path.join(src, name)
+    dst_path = os.path.join(dst, name)
+    if os.path.isdir(src_path) and not os.path.islink(src_path):
+        if os.path.exists(dst_path):
+            shutil.rmtree(dst_path)
+        shutil.copytree(src_path, dst_path, symlinks=True)
+    else:
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+        shutil.copy2(src_path, dst_path)
+PY
+  rm -rf "$tmpdir"
+  trap - EXIT
+}
+
+main() {
+  parse_args "$@"
+  if [[ -n "$ROOT_OVERRIDE" ]]; then
+    ROOT_DIR=$(sanitize_path "$ROOT_OVERRIDE")
+  fi
+  if [[ ! -d "$ROOT_DIR" ]]; then
+    error "Root directory '$ROOT_DIR' does not exist"
+  fi
+  local metadata_path="$ROOT_DIR/$METADATA_FILE"
+  if [[ -z "$REPO_IDENTIFIER" ]]; then
+    REPO_IDENTIFIER="$(metadata_value "$metadata_path" repo)"
+  fi
+  if [[ -z "$REPO_IDENTIFIER" && -n "${SLIDESHOW_MANAGER_REPO:-}" ]]; then
+    REPO_IDENTIFIER="${SLIDESHOW_MANAGER_REPO}"
+  fi
+  if [[ -z "$REPO_IDENTIFIER" ]]; then
+    local derived
+    derived=$(repo_from_git_remote || true)
+    if [[ -n "$derived" ]]; then
+      REPO_IDENTIFIER="$derived"
+    fi
+  fi
+  if [[ -z "$REPO_IDENTIFIER" && -n "${SLIDESHOW_MANAGER_REPO:-}" ]]; then
+    REPO_IDENTIFIER="${SLIDESHOW_MANAGER_REPO}"
+  fi
+  if [[ -z "$REMOTE_URL" ]]; then
+    if [[ -d "$ROOT_DIR/.git" && command -v git >/dev/null 2>&1 ]]; then
+      REMOTE_URL=$(git -C "$ROOT_DIR" remote get-url origin 2>/dev/null || true)
+    fi
+  fi
+  if [[ -z "$REMOTE_URL" ]]; then
+    REMOTE_URL="$(identifier_to_remote_url "$REPO_IDENTIFIER")"
+  fi
+  if [[ -z "$REMOTE_URL" ]]; then
+    error "Unable to resolve repository URL."
+  fi
+  ensure_branch "$REMOTE_URL" "$REPO_IDENTIFIER"
+  log "Updating to branch '$BRANCH'"
+  if [[ -d "$ROOT_DIR/.git" && command -v git >/dev/null 2>&1 ]]; then
+    update_with_git "$REMOTE_URL" "$BRANCH"
+  else
+    update_without_git "$REMOTE_URL" "$BRANCH"
+  fi
+  install_dependencies
+  write_metadata "$REPO_IDENTIFIER" "$BRANCH"
+  log "Update complete"
+}
+
+main "$@"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,12 +17,31 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["jest", "node"],
+    "types": [
+      "jest",
+      "node"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add install/update shell scripts that default to the newest version-x.x.x branch and support git-less deployments
- expose REST endpoints and a dashboard page to list version branches and trigger updates from the web UI
- document required repository configuration and add utilities for fetching version branches from GitHub

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any and @typescript-eslint/no-unused-vars violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e16a6b1bec832d9e5f8ea35bc6c305