### PR TITLE
Preserve device data and refresh update tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ sudo journalctl -u slideshow-manager.service -f
 
 ## Updates
 
-Für Aktualisierungen steht `scripts/update.sh` bereit. Das Skript lädt den gewünschten Branch erneut, synchronisiert den Inhalt nach `/opt/Slideshow_Manager/current`, installiert geänderte Python-Abhängigkeiten in der bestehenden virtuellen Umgebung und startet den Dienst neu.
+Für Aktualisierungen steht `scripts/update.sh` bereit. Das Skript lädt den gewünschten Branch erneut, synchronisiert den Inhalt nach `/opt/Slideshow_Manager`, installiert geänderte System- und Python-Abhängigkeiten und startet den Dienst neu.
 
 ```bash
-sudo /opt/Slideshow_Manager/current/scripts/update.sh
+sudo /opt/Slideshow_Manager/scripts/update.sh
 ```
 
 Auch hier kannst du die Umgebungsvariablen `SLIDESHOW_MANAGER_DEFAULT_REPO` und `SLIDESHOW_MANAGER_BRANCH` setzen, um auf andere Branches oder Forks zu wechseln.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -6,7 +6,9 @@ SERVICE_NAME="slideshow-manager"
 ENV_FILE="/etc/slideshow-manager.env"
 DEFAULT_REPO="${SLIDESHOW_MANAGER_DEFAULT_REPO:-https://github.com/joni123467/Slideshow_Manager}"
 BRANCH="${SLIDESHOW_MANAGER_BRANCH:-main}"
+SERVICE_USER="${SLIDESHOW_MANAGER_USER:-slideshowmgr}"
 TMP_DIR=""
+declare -a PERSISTENT_PATHS=("slideshow_manager/data/devices.json")
 
 cleanup() {
   if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
@@ -24,6 +26,54 @@ require_root() {
 
 log() {
   echo "[update] $*" >&2
+}
+
+find_pkg_manager() {
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "apt"
+  elif command -v dnf >/dev/null 2>&1; then
+    echo "dnf"
+  elif command -v yum >/dev/null 2>&1; then
+    echo "yum"
+  elif command -v pacman >/dev/null 2>&1; then
+    echo "pacman"
+  elif command -v zypper >/dev/null 2>&1; then
+    echo "zypper"
+  else
+    echo ""
+  fi
+}
+
+install_system_dependencies() {
+  local pkg_manager
+  pkg_manager="$(find_pkg_manager)"
+  local packages=(python3 python3-venv python3-pip curl tar git)
+  case "${pkg_manager}" in
+    apt)
+      packages+=(python3-dev build-essential libpam0g-dev)
+      log "Installiere Pakete über apt (${packages[*]})"
+      apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+      ;;
+    dnf|yum)
+      packages+=(python3-devel gcc gcc-c++ make pam-devel)
+      log "Installiere Pakete über ${pkg_manager} (${packages[*]})"
+      "${pkg_manager}" install -y "${packages[@]}"
+      ;;
+    pacman)
+      packages+=(base-devel pam)
+      log "Installiere Pakete über pacman (${packages[*]})"
+      pacman -Sy --noconfirm "${packages[@]}"
+      ;;
+    zypper)
+      packages+=(python3-devel gcc gcc-c++ make pam-devel)
+      log "Installiere Pakete über zypper (${packages[*]})"
+      zypper --non-interactive install "${packages[@]}"
+      ;;
+    *)
+      log "Keinen Paketmanager gefunden – stelle sicher, dass python3, pip, tar, curl, ein C-Compiler sowie PAM-Header installiert sind."
+      ;;
+  esac
 }
 
 fetch_sources() {
@@ -44,21 +94,79 @@ fetch_sources() {
 
 sync_release() {
   local source_dir="$1"
-  rm -rf "${INSTALL_ROOT}/current"
-  mkdir -p "${INSTALL_ROOT}/current"
-  cp -a "${source_dir}/." "${INSTALL_ROOT}/current/"
-  chmod +x "${INSTALL_ROOT}/current"/scripts/*.sh
-}
+  local venv_backup=""
+  local data_backup=""
 
-install_dependencies() {
-  local venv_dir="${INSTALL_ROOT}/.venv"
-  if [[ ! -d "${venv_dir}" ]]; then
-    log "Virtuelle Umgebung fehlt – führe zunächst install.sh aus."
+  if [[ ! -d "${INSTALL_ROOT}" ]]; then
+    log "Es wurde keine Installation gefunden. Bitte install.sh ausführen."
     exit 1
   fi
+
+  if [[ -d "${INSTALL_ROOT}/.venv" ]]; then
+    venv_backup="$(mktemp -d)"
+    mv "${INSTALL_ROOT}/.venv" "${venv_backup}/.venv"
+  fi
+
+  if [[ ${#PERSISTENT_PATHS[@]} -gt 0 ]]; then
+    local backup_dir
+    backup_dir="$(mktemp -d)"
+    local preserved=0
+    for rel_path in "${PERSISTENT_PATHS[@]}"; do
+      if [[ -e "${INSTALL_ROOT}/${rel_path}" ]]; then
+        preserved=1
+        local backup_target="${backup_dir}/${rel_path}"
+        mkdir -p "$(dirname "${backup_target}")"
+        cp -a "${INSTALL_ROOT}/${rel_path}" "${backup_target}"
+      fi
+    done
+    if [[ ${preserved} -eq 1 ]]; then
+      data_backup="${backup_dir}"
+    else
+      rm -rf "${backup_dir}"
+    fi
+  fi
+
+  find "${INSTALL_ROOT}" -mindepth 1 -maxdepth 1 ! -name ".venv" -exec rm -rf {} +
+  cp -a "${source_dir}/." "${INSTALL_ROOT}/"
+
+  if [[ -n "${venv_backup}" && -d "${venv_backup}/.venv" ]]; then
+    mv "${venv_backup}/.venv" "${INSTALL_ROOT}/.venv"
+    rm -rf "${venv_backup}"
+  fi
+
+  if [[ -n "${data_backup}" ]]; then
+    for rel_path in "${PERSISTENT_PATHS[@]}"; do
+      if [[ -e "${data_backup}/${rel_path}" ]]; then
+        local target_dir="${INSTALL_ROOT}/$(dirname "${rel_path}")"
+        mkdir -p "${target_dir}"
+        cp -a "${data_backup}/${rel_path}" "${INSTALL_ROOT}/${rel_path}"
+      fi
+    done
+    rm -rf "${data_backup}"
+  fi
+
+  if compgen -G "${INSTALL_ROOT}/scripts/*.sh" >/dev/null; then
+    chmod +x "${INSTALL_ROOT}"/scripts/*.sh
+  fi
+}
+
+install_python_dependencies() {
+  local venv_dir="${INSTALL_ROOT}/.venv"
+  if [[ ! -d "${venv_dir}" ]]; then
+    log "Virtuelle Umgebung fehlt – erstelle neue Umgebung"
+    python3 -m venv "${venv_dir}"
+  fi
   source "${venv_dir}/bin/activate"
-  pip install --upgrade pip
-  pip install --no-cache-dir -r "${INSTALL_ROOT}/current/requirements.txt"
+  pip install --upgrade pip setuptools wheel
+  pip install --no-cache-dir -r "${INSTALL_ROOT}/requirements.txt"
+}
+
+set_permissions() {
+  if id "${SERVICE_USER}" >/dev/null 2>&1; then
+    chown -R "${SERVICE_USER}:${SERVICE_USER}" "${INSTALL_ROOT}"
+  else
+    log "Warnung: Dienstnutzer ${SERVICE_USER} existiert nicht – Überspringe chown."
+  fi
 }
 
 restart_service() {
@@ -68,10 +176,12 @@ restart_service() {
 
 main() {
   require_root
+  install_system_dependencies
   local source_dir
   source_dir="$(fetch_sources)"
   sync_release "${source_dir}"
-  install_dependencies
+  install_python_dependencies
+  set_permissions
   restart_service
   log "Update abgeschlossen."
 }


### PR DESCRIPTION
## Summary
- preserve device storage files during reinstallation by backing them up before syncing new releases
- align the updater with the installer by re-installing required system packages, restoring persistent data, and reapplying service-user permissions
- update the documentation to reference the new installation layout without the `current` directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1876615d4832d8217c9c2f0e42626